### PR TITLE
fixed mismatched url

### DIFF
--- a/developers/weaviate/client-libraries/community.md
+++ b/developers/weaviate/client-libraries/community.md
@@ -9,8 +9,8 @@ Weaviate supports client libraries for these languages:
 
 - [Python](/developers/weaviate/client-libraries/python)
 - [TypeScript](/developers/weaviate/client-libraries/typescript)
-- [Go](/developers/weaviate/client-libraries/java)
-- [Java](/developers/weaviate/client-libraries/go)
+- [Go](/developers/weaviate/client-libraries/go)
+- [Java](/developers/weaviate/client-libraries/java)
 
 Members of the Weaviate community provide client libraries for some additional languages. These community contributed libraries are not officially maintained by Weaviate. However, we are very grateful for the work these developers do, and we want to share it with you.
 


### PR DESCRIPTION
- Changed the URL for Go client library link to /developers/weaviate/client-libraries/go
- Changed the URL for Java client library link to /developers/weaviate/client-libraries/java

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)
- [x] **Website** updates (non-breaking change to update main page, company pages, pricing, etc)
- [ ] **Content** updates – **blog**, **podcast** (non-breaking change to add/update content)
- [x] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How Has This Been Tested?

<!-- Please select all options that apply -->

- [x] **Github action** – automated build completed without errors
- [x] **Local build** - the site works as expected when running `yarn start`

> note, you can run `yarn verify-links` to test site links locally
